### PR TITLE
Update Lighthouse build from source deps

### DIFF
--- a/coins/overview-eth/guide-how-to-stake-on-eth2-with-lighthouse.md
+++ b/coins/overview-eth/guide-how-to-stake-on-eth2-with-lighthouse.md
@@ -475,7 +475,7 @@ source ~/.bashrc
 Install rust dependencies.
 
 ```
-sudo apt install -y git gcc g++ make cmake pkg-config llvm-dev libclang-dev clang
+sudo apt install -y git gcc g++ make cmake pkg-config libssl-dev llvm-dev libclang-dev clang
 ```
 
 ## :bulb: 5. Install Lighthouse

--- a/coins/overview-eth/guide-how-to-stake-on-eth2-with-lighthouse.md
+++ b/coins/overview-eth/guide-how-to-stake-on-eth2-with-lighthouse.md
@@ -475,7 +475,7 @@ source ~/.bashrc
 Install rust dependencies.
 
 ```
-sudo apt install -y git gcc g++ make cmake pkg-config libssl-dev
+sudo apt install -y git gcc g++ make cmake pkg-config llvm-dev libclang-dev clang
 ```
 
 ## :bulb: 5. Install Lighthouse


### PR DESCRIPTION
Lighthouse recently added `clang` as a build dependency per: https://lighthouse-book.sigmaprime.io/installation-source.html#ubuntu.